### PR TITLE
typo fix: \ is missing in the command concatenation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ export COMMIT="COMMIT-UUID"
 
 gosec -fmt json -log log.txt ./... | \
 ./codacy-gosec-"<version>" | \
-curl -XPOST -L -H "project-token: $PROJECT_TOKEN"
+curl -XPOST -L -H "project-token: $PROJECT_TOKEN" \
     -H "Content-type: application/json" -d @- \
     "https://api.codacy.com/2.0/commit/$COMMIT/issuesRemoteResults"
 


### PR DESCRIPTION
Just fixing a tiny typo in the README example.