### PR TITLE
fix: Include tool-description.md in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN go run main.go -docFolder=../docs
 FROM alpine:3.11
 
 COPY --from=builder /docs /docs
+COPY docs/tool-description.md /docs/
 COPY entry.sh /
 
 RUN adduser -u 2004 -D docker && chown -R docker:docker /docs


### PR DESCRIPTION
On https://github.com/codacy/codacy-tools/pull/477 we noticed that the [tool-description.md file](https://github.com/codacy/codacy-gosec/blob/master/docs/tool-description.md) wasn't being read correctly on the codacy-tools side.

This change ensures that the file is also included in the Docker image.