### PR TITLE
doc: Add missing instruction for enabling Gosec DOCS-414

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A standalone tool that converts gosec results to Codacy's format. It allows the 
 
 To get your gosec results into Codacy you'll need to:
 
--   Enable Gosec on your repository **Code patterns** page
+-   Enable Gosec and configure the corresponding code patterns on your repository **Code patterns** page
 -   Enable the setting **Run analysis through build server** on your repository **Settings**, tab **General**, **Repository analysis**
 -   Obtain a [project API token](https://docs.codacy.com/codacy-api/api-tokens/#project-api-tokens)
 -   Install [gosec](https://github.com/securego/gosec#install)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A standalone tool that converts gosec results to Codacy's format. It allows the 
 
 To get your gosec results into Codacy you'll need to:
 
--   Enable Gosec and configure the corresponding code patterns on your repository **Code patterns** page
+-   [Enable Gosec](https://docs.codacy.com/repositories-configure/configuring-code-patterns/) and configure the corresponding code patterns on your repository **Code patterns** page
 -   Enable the setting **Run analysis through build server** on your repository **Settings**, tab **General**, **Repository analysis**
 -   Obtain a [project API token](https://docs.codacy.com/codacy-api/api-tokens/#project-api-tokens)
 -   Install [gosec](https://github.com/securego/gosec#install)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ A standalone tool that converts gosec results to Codacy's format. It allows the 
 
 To get your gosec results into Codacy you'll need to:
 
--   Enable the setting “Run analysis through build server” under your repository Settings > General > Repository analysis
+-   Enable Gosec on your repository **Code patterns** page
+-   Enable the setting **Run analysis through build server** on your repository **Settings**, tab **General**, **Repository analysis**
 -   Obtain a [project API token](https://docs.codacy.com/codacy-api/api-tokens/#project-api-tokens)
 -   Install [gosec](https://github.com/securego/gosec#install)
 -   Download the `codacy-gosec` binary (or Java jar) from [the releases page](https://github.com/codacy/codacy-gosec/releases)


### PR DESCRIPTION
Adds the missing instruction for enabling Gosec on the Code patterns page.